### PR TITLE
docs: update the event info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ This repository contains all the public events, including talks, workshops, and 
 
 | Title                                                             | Type     | Venue                  | Date                 |
 |-------------------------------------------------------------------|----------|------------------------|----------------------|
-| [Token Security Benchmark](workshops/2023-token2049-ctf-workshop) | Workshop | Token2049 CTF Workshop | September 13rd, 2023 |
+| [2023 MetaTrust Web3 CTF Workshop](workshops/2023-token2049-ctf-workshop) | Workshop | Online: https://build.bewater.xyz/en/campaigns/28 | September 13rd, 2023 |


### PR DESCRIPTION
Update the 2023 MetaTrust Web3 Security CTF event information.